### PR TITLE
docs: add Parker signup + onboarding links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,15 @@
 
 It contains the production-facing prompts, skills, system instructions, methodology, templates, generalized knowledge, fixtures, and evals that can power Parker for users.
 
+> **New to Parker?** New customers get 1 month free with code **`PARKERBRAIN`** — limited spots → **[heyparker.ai](https://heyparker.ai)**
+>
+> 📺 **Setting up your brand's brain?** Watch the [setup walkthrough](https://drive.google.com/file/d/1zxs88XEx1-zdbHjO-DfNc70a3zuGYnuF/view) for full onboarding instructions.
+
 This repo is not the private OS/lab. Raw prompt experiments, test brand outputs, MCP snapshots, planning notes, raw expert inboxes, and private reasoning traces stay in the OS/lab repo unless they are sanitized and promoted.
 
 ## Open Source Availability
 
-This repository is public source-available under the [PolyForm Noncommercial License 1.0.0](./LICENSE). You may use, study, modify, and share it for noncommercial purposes.
+This repository is public source-available under the [PolyForm Noncommercial License 1.0.0](./LICENSE.md). You may use, study, modify, and share it for noncommercial purposes.
 
 Commercial use is not permitted under this license. If you need commercial rights, you need a separate written license from the copyright holder.
 
@@ -29,6 +33,12 @@ That means:
 `parker-brain` is meant to be cloned as the read-only factory. **A brand brain you build from it lives in its own separate repository — you do not build on top of this repo.** When you onboard a brand, create a new git repo for that brand and write every output there; this clone supplies the prompts, skills, methodology, and craft layer, and the brand repo is the product. `prompts/onboarding-runner.md` is the executable cold-start sequence and `prompts/README.md` is the why behind it.
 
 The data tools the prompts call run through the **Parker MCP**. If it is not connected, Parker has no live reach into the ad account, organic socials, reviews, surveys, or the competitor ad library — the Parker MCP is the one connection that brings all of it online at once, though independent platform exports can feed the same evidence more manually. `system/parker-tools.md` is the canonical tool inventory.
+
+To stand one up, sign up and connect the Parker MCP at **[heyparker.ai](https://heyparker.ai)** (new customers get 1 month free with code `PARKERBRAIN`, limited spots), then run this in Claude Code:
+
+```
+Set up my brain for my brand [brand] in a new private repo, follow instructions in here: https://github.com/real-simple-labs/parker-brain
+```
 
 **The skills are still under testing.** They ship as foundations — the full context and methodology so a team can stand these capabilities up and build on them — not as guaranteed-final products. Scriptwriting in particular is actively being trained. Treat skill output as a strong starting point a human should review.
 


### PR DESCRIPTION
## Why

Small additive tweaks so someone who finds this public repo on their own has a path to actually use it — without restructuring the existing README.

## What changed (README.md only, +11/−1)

- **Sign-up CTA near the top** — `PARKERBRAIN` (1 month free) + a link to **heyparker.ai**, plus the **setup walkthrough video**.
- **Setup prompt in "Using this for a brand"** — the exact Claude Code prompt to stand up a brand brain, with the heyparker.ai / Parker MCP pointer.
- **Fixed broken license link** (`./LICENSE` → `./LICENSE.md`).

Everything else in the README is unchanged. No prompts, skills, or knowledge touched.

## Optional follow-up

- The setup video is a Google Drive link — works, but a YouTube/Loom/heyparker.ai host would be more durable for a public README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
