### PR TITLE
feat: set up github repo automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ That means:
 
 ## Using this for a brand
 
-`parker-brain` is meant to be cloned as the read-only factory. **A brand brain you build from it lives in its own separate repository — you do not build on top of this repo.** When you onboard a brand, create a new git repo for that brand and write every output there; this clone supplies the prompts, skills, methodology, and craft layer, and the brand repo is the product. `prompts/onboarding-runner.md` is the executable cold-start sequence and `prompts/README.md` is the why behind it.
+`parker-brain` is meant to be cloned as the read-only factory. **A brand brain you build from it lives in its own separate repository — you do not build on top of this repo.** When you onboard a brand, create a new git repo for that brand using the MCP's `setup_github_repo` tool and write every output there. Commit and push often, as soon as you make any changes. This clone supplies the prompts, skills, methodology, and craft layer, and the brand repo is the product. `prompts/onboarding-runner.md` is the executable cold-start sequence and `prompts/README.md` is the why behind it.
 
 The data tools the prompts call run through the **Parker MCP**. If it is not connected, Parker has no live reach into the ad account, organic socials, reviews, surveys, or the competitor ad library — the Parker MCP is the one connection that brings all of it online at once, though independent platform exports can feed the same evidence more manually. `system/parker-tools.md` is the canonical tool inventory.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates the brand onboarding documentation in README.md to promote automated GitHub repository setup through the Parker MCP tool and emphasize version control best practices.

## Changes Made

**README.md** - Updated the "Using this for a brand" section:
- Replaced manual brand repository setup instructions with a directive to use the Parker MCP's `setup_github_repo` tool for creating new brand repositories
- Added explicit guidance to "commit and push often, as soon as you make any changes"
- Maintained the architectural clarity that `parker-brain` is the read-only factory template while brand repositories are separate products built from it

## Why This Change

The Parker MCP (Model Context Protocol) includes a `setup_github_repo` tool designed to automate the initialization of brand-specific repositories. By promoting this tool in the onboarding docs, the change:

**Reduces friction and inconsistency**: Automated setup prevents configuration errors and ensures every brand repository is initialized with the correct structure, permissions, and tooling from the start, rather than relying on manual, error-prone steps.

**Ensures architectural clarity**: Explicitly directing users to create brand repos as separate repositories (not as modifications to the cloned parker-brain) reinforces the intended workflow: parker-brain stays as the stable, reusable product intelligence layer that teams can pull improvements from, while brand-specific learning and customization happens in isolated brand repositories.

**Promotes best practices**: The added emphasis on frequent commits and pushes codifies version control discipline into the onboarding workflow, encouraging teams to capture iterations and changes incrementally rather than in large batches.

**Enables future tooling**: By standardizing on the MCP tool for setup, the workflow becomes more amenable to automation, monitoring, and integration with other tools in the Parker ecosystem.

## Impact

- **Scope**: Documentation only (README.md)
- **User-facing**: Yes — this changes how new brands are onboarded
- **Workflow impact**: Shifts from manual setup to tool-driven setup; adds emphasis on version control practices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->