### PR TITLE
Add the manufactured-intimacy opener as an AI tell

### DIFF
--- a/global/knowledge/creative-strategy/ai-writing-tells.md
+++ b/global/knowledge/creative-strategy/ai-writing-tells.md
@@ -82,7 +82,7 @@ The question form deserves its own name because it is one of the biggest tells: 
 
 ### 9. Sycophancy and throat-clearing
 
-Openers that praise the premise or restate the brief before saying anything: "Great question," "In today's fast-paced world," "When it comes to comfort." The first line of any creative deliverable is the most expensive real estate it has; a throat-clear spends it on nothing. Related: the "whether you're a busy mom or a weekend athlete" audience-enumeration, which names everyone and lands with no one.
+Openers that praise the premise or restate the brief before saying anything: "Great question," "In today's fast-paced world," "When it comes to comfort." The first line of any creative deliverable is the most expensive real estate it has; a throat-clear spends it on nothing. Related: the "whether you're a busy mom or a weekend athlete" audience-enumeration, which names everyone and lands with no one. And the **manufactured-intimacy opener** — "Okay, can I be real for a second?" "Can I be honest with you?" "Let me be real." "Real talk." — performed vulnerability that asks permission to be authentic instead of just being it. It shows up on AI-written hooks constantly; a real person opens on the confession, not the request to make one. (Spoken treatment: Tell 13 in `spoken-script-voice.md`.)
 
 ### 10. Elegant variation
 

--- a/global/knowledge/creative-strategy/spoken-script-voice.md
+++ b/global/knowledge/creative-strategy/spoken-script-voice.md
@@ -186,6 +186,11 @@ AI coins modifiers by jamming two words together with a hyphen: compounds nobody
 - WRONG (AI): "A conversion-ready close with a premium-feel finish and a trust-first tone."
 - RIGHT: "It ends by asking for the sale, it looks expensive, and it earns the trust before it asks." Plain words in plain sentences, no minted compounds.
 
+### Tell 13: The manufactured-intimacy opener
+AI loves to open a hook by asking permission to be honest — "Okay, can I be real for a second?" "Can I be honest with you?" "Let me be real." "Real talk." It is performed vulnerability: a formula that announces authenticity instead of just being authentic, and it shows up on AI-written hooks constantly. A real person doesn't ask to be real, they just say the thing. It is a cousin of the rhetorical self-question (Tell 11) — a question the speaker asks and never waits on — with a fake-confession coat. Cut the wind-up and open on the actual confession or the actual stakes.
+- WRONG (AI): "Okay, can I be real for a second? These are the only jeans I've worn in a month."
+- RIGHT: "I've worn these same jeans every day for a month. My wife's starting to worry." The realness is in the specific admission, not the request to make one.
+
 ---
 
 ## Part 3: The spoken-register rules

--- a/scripts/voice-lint.py
+++ b/scripts/voice-lint.py
@@ -109,6 +109,18 @@ PATTERNS = [
         r"array)|provides?\s+an?\s+(range|variety|seamless|unmatched)|"
         r"delivers?\s+(unmatched|unparalleled|exceptional))", re.I),
      "'features/offers/delivers a' where 'is/has' belongs"),
+    ("manufactured-intimacy opener", re.compile(
+        r"\b(can\s+i\s+be\s+(real|honest|straight|100)"
+        r"(\s+with\s+you)?(\s+for\s+a\s+(sec|second|minute))?"
+        r"|let\s+me\s+be\s+(real|honest|straight)"
+        r"|can\s+we\s+be\s+(real|honest)"
+        r"|let\s+me\s+keep\s+it\s+(real|100|a\s+hundred)"
+        r"|keeping\s+it\s+(real|100)"
+        r"|i'?m(a|\s+gonna)?\s+be\s+(real|honest)\s+with\s+you"
+        r"|real\s+talk)\b", re.I),
+     "manufactured-intimacy opener — performed vulnerability that asks "
+     "permission to be real instead of just being it; open on the actual "
+     "confession, not the request to make one"),
     ("rhetorical self-question", re.compile(
         r"(\b(sound\s+familiar|crazy,?\s+right|guess\s+what|"
         r"you\s+know\s+what('?s)?\s+(crazy|wild|funny)|"


### PR DESCRIPTION
## What this does

Adds one AI tell that PR #17 didn't include (it was written after #17 merged): the **manufactured-intimacy opener** — "Okay, can I be real for a second?" / "Can I be honest with you?" / "Real talk" / "Let me keep it 100." Performed vulnerability that asks permission to be authentic instead of just being it. It shows up on AI-written hooks constantly.

Three spots, same as every other tell:
- **Tell 13** in `spoken-script-voice.md` — the spoken treatment, with a WRONG/RIGHT pair.
- Folded into the throat-clearing family in `ai-writing-tells.md`.
- A **voice-lint pattern** that catches the permission-to-be-real formula — verified it flags all four variants and does NOT false-flag genuine casual lines ("honestly I forgot I had them on").

## Why separate from #17

#17 was already merged when this tell came up, so it couldn't ride along. Small, self-contained follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR adds a new AI-writing tell for “manufactured intimacy” openers—phrases that ask permission to be authentic (“can I be real?”, “can I be honest?”, “real talk”) instead of opening with genuine candor. The change codifies this pattern because it shows up often in AI-written hooks and overlaps with the broader throat-clearing style already documented in the strategy notes.

Updates include:
- A new Tell 13 in `spoken-script-voice.md` with a WRONG/RIGHT example pair showing how to replace performative vulnerability with a direct, specific opening.
- A related note in `ai-writing-tells.md` expanding the throat-clearing family to explicitly call out this permission-to-be-real formula.
- A new `voice-lint.py` pattern that flags these manufactured-intimacy openers while avoiding false positives on ordinary casual phrasing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->