### PR TITLE
docs: add best-use-cases placeholder (global cross-team knowledge tier)

### DIFF
--- a/global/knowledge/best-use-cases.md
+++ b/global/knowledge/best-use-cases.md
@@ -1,0 +1,3 @@
+# Best use cases for Parker
+
+_Placeholder — to be filled in._


### PR DESCRIPTION
## Summary

Placeholder skeleton for `global/knowledge/global/best-use-cases.md` — the cross-team "best use cases / how to use Parker" literacy doc that `system/master-file-structure.md` already reserves (as `references/knowledge/global/how-to-use-parker.md`). This stands up the cross-team `global/` knowledge tier alongside `creative-strategy/` and `performance/`.

**Draft — outline only, content to follow.** Opening early as a draft to start the PR. Sections to fill in: what Parker is best at, best use cases by phase / craft skill / connected data, where a human still leads, and how to get the best results.

### Follow-ups before marking ready
- [ ] Fill in the section content
- [ ] Register the new `global/knowledge/global/` tier in `system/master-file-structure.md` and `system/parker-system-map.md`
- [ ] Add a `release-notes/` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added a placeholder outline for Parker’s new global “best use cases / how to use Parker” knowledge doc, creating the `global/knowledge` entry point for the cross-team literacy tier without adding content yet.

This sets up the intended shared reference structure so the document can later capture:
- what Parker is best at
- best use cases by phase, craft skill, and connected data
- where human judgment still leads
- how to get the best results

<!-- end of auto-generated comment: release notes by coderabbit.ai -->