### PR TITLE
docs: add AGENTS.md with Cursor Cloud dev environment notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS.md
+
+See `CLAUDE.md` for the full Parker product-brain operating contract, repo rules, and prompt/skill/knowledge standards. That file is the source of truth for how to work in this repository.
+
+## Cursor Cloud specific instructions
+
+This is a documentation / prompt / skill "product brain" repo, not a conventional application:
+
+- **No dependencies, no build.** There is no `package.json`, `requirements.txt`, or lockfile. The content is markdown. The only executable code is `scripts/*.py` (pure Python 3 standard library — no `pip install` needed) plus `scripts/propagate-to-brand-brains.sh` (bash). System `python3` (3.12) is all that's required.
+- **No automated test suite.** `evals/` is an empty placeholder. The scripts' `--check` modes are the closest thing to lint/tests.
+
+Runnable tooling (all from the repo root):
+
+- `python3 scripts/sync-open-loops-core.py --check` — drift lint: verifies the marker-delimited shared blocks embedded across prompts/templates still match their source files. Exit 1 on drift. Run (without `--check`) to fix drift.
+- `python3 scripts/build-doc-map.py` — regenerates the creative-strategy doc catalog inside `global/knowledge/creative-strategy/expertise-routing.md`. Must be run after adding/editing any doc in `global/knowledge/creative-strategy/`. The region between the `DOC-MAP` markers is generated — never hand-edit it. Idempotent when the catalog is already in sync.
+- `python3 scripts/voice-lint.py DRAFT_FILE` — deterministic AI-writing-tell scan. Runs against creative *deliverable* drafts (scripts, hooks, headlines, copy), never against repo context/prompt/system docs. Exit 1 when flags are found.
+- `python3 scripts/grounding-check.py OUTPUT_FILE [BRAIN_ROOT]` — traces quoted verbatims and cited file paths in a creative/strategy output against the brain on disk. `BRAIN_ROOT` defaults to the current directory. Exit 1 on findings.
+- `scripts/propagate-to-brand-brains.sh [brand-repo ...]` — re-ships the factory bundle into standing brand-brain repos. Needs target repo paths (args or `PARKER_BRAND_BRAIN_REPOS`); it is not runnable standalone in this repo and writes to *external* brand repos, so do not run it as a self-test here.
+
+Note: `.claude/skills/` and `.claude/agents/` are loaded by Claude Code at runtime; the `.claude/hooks/` referenced by some docs ship only with the brand-routines template (`templates/brand-routines/`), not with this factory repo.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,12 +9,3 @@ This is a documentation / prompt / skill "product brain" repo, not a conventiona
 - **No dependencies, no build.** There is no `package.json`, `requirements.txt`, or lockfile. The content is markdown. The only executable code is `scripts/*.py` (pure Python 3 standard library — no `pip install` needed) plus `scripts/propagate-to-brand-brains.sh` (bash). System `python3` (3.12) is all that's required.
 - **No automated test suite.** `evals/` is an empty placeholder. The scripts' `--check` modes are the closest thing to lint/tests.
 
-Runnable tooling (all from the repo root):
-
-- `python3 scripts/sync-open-loops-core.py --check` — drift lint: verifies the marker-delimited shared blocks embedded across prompts/templates still match their source files. Exit 1 on drift. Run (without `--check`) to fix drift.
-- `python3 scripts/build-doc-map.py` — regenerates the creative-strategy doc catalog inside `global/knowledge/creative-strategy/expertise-routing.md`. Must be run after adding/editing any doc in `global/knowledge/creative-strategy/`. The region between the `DOC-MAP` markers is generated — never hand-edit it. Idempotent when the catalog is already in sync.
-- `python3 scripts/voice-lint.py DRAFT_FILE` — deterministic AI-writing-tell scan. Runs against creative *deliverable* drafts (scripts, hooks, headlines, copy), never against repo context/prompt/system docs. Exit 1 when flags are found.
-- `python3 scripts/grounding-check.py OUTPUT_FILE [BRAIN_ROOT]` — traces quoted verbatims and cited file paths in a creative/strategy output against the brain on disk. `BRAIN_ROOT` defaults to the current directory. Exit 1 on findings.
-- `scripts/propagate-to-brand-brains.sh [brand-repo ...]` — re-ships the factory bundle into standing brand-brain repos. Needs target repo paths (args or `PARKER_BRAND_BRAIN_REPOS`); it is not runnable standalone in this repo and writes to *external* brand repos, so do not run it as a self-test here.
-
-Note: `.claude/skills/` and `.claude/agents/` are loaded by Claude Code at runtime; the `.claude/hooks/` referenced by some docs ship only with the brand-routines template (`templates/brand-routines/`), not with this factory repo.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context & motivation

`parker-brain` is a documentation / prompt / skill "product brain" repo, not a conventional application. When a new agent (or human) first sets up here, it isn't obvious that there are no dependencies to install and no build step — the only executable code is a handful of pure-stdlib Python 3 helper scripts under `scripts/`. This PR captures those durable, non-obvious facts so future Cursor Cloud agents can operate the tooling without rediscovering it.

## What changed

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section that:
  - States there are no deps / no build / no automated test suite (only `python3` 3.12 is required).
  - Documents how to run each helper script and what its exit codes mean: `sync-open-loops-core.py --check` (block-drift lint), `build-doc-map.py` (regenerates the creative-strategy doc catalog; must run after editing knowledge docs; region between `DOC-MAP` markers is generated), `voice-lint.py` (AI-writing-tell scan on creative drafts), and `grounding-check.py` (traces quotes/citations against the brain).
  - Notes `propagate-to-brand-brains.sh` writes to *external* brand repos and shouldn't be run as a self-test here.
  - Points at `CLAUDE.md` as the source of truth for repo rules.

No existing files were modified; content and scripts are unchanged.

## Verification

Ran the repo's tooling end-to-end from a clean checkout:

- `python3 scripts/sync-open-loops-core.py --check` → `Clean: every synced block matches its source.` (exit 0)
- `python3 scripts/build-doc-map.py` → `Wrote catalog: 26 docs.` and clean `git status` (idempotent, catalog already in sync)
- `python3 scripts/voice-lint.py <ai-draft>` → 8 flags, exit 1; on a clean human draft → 0 flags, exit 0
- `python3 scripts/grounding-check.py <output> /workspace` → resolved real cited paths, flagged a fake one as MISSING, exit 1

The update script for the environment is simply `python3 --version` (nothing to install).

## Watch-outs / future

- The `DOC-MAP` region in `global/knowledge/creative-strategy/expertise-routing.md` is generated by `build-doc-map.py` — don't hand-edit it.
- `.claude/hooks/` referenced by some docs ships only with `templates/brand-routines/`, not with this factory repo.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf34c422-e951-4b53-a4c9-9075e65b1c26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf34c422-e951-4b53-a4c9-9075e65b1c26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added `AGENTS.md` to document Cursor Cloud development guidance for the documentation and prompt repository.
- Clarified that `CLAUDE.md` is the source of truth and that the repository has no dependencies, build step, or automated test suite.
- Documented helper-script usage, exit codes, generated documentation mapping, and external brand-repository propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->