### PR TITLE
fix: make /update-brain pin bumps more reliable

### DIFF
--- a/migrations/v2.md
+++ b/migrations/v2.md
@@ -1,0 +1,7 @@
+# v2 — update-brain reliability
+
+**Applies to:** brand brains pinned at `v1` (or earlier, after `v1` has already been applied). Brains born on `v2` or later already carry this — running it is a no-op.
+
+**What changes:** `/update-brain` got clearer about connected vs decoupled mode: it reads migrations before framing the comparison, and it makes explicit that accepting a later release still runs every skipped migration in between. No brand-repo layout changes.
+
+**Nothing to do on the brand side.** The pin bump's normal re-sync of the copied executable layer picks up the clearer `.claude/skills/update-brain/` skill. Record migrations applied through `v2` in `running-notes/standard-sync.md` and set `parker_config.json` `parker_brain_version` to `v2` as part of the usual pin-bump bookkeeping.

--- a/release-notes/2026-07-10-v2-update-brain-reliability.md
+++ b/release-notes/2026-07-10-v2-update-brain-reliability.md
@@ -1,0 +1,19 @@
+# 2026-07-10 — v2: more reliable `/update-brain` updates and migrations
+
+## What shipped
+
+`/update-brain` (the brand-routine skill at `templates/brand-routines/claude/skills/update-brain/`) got two reliability fixes for connected brains:
+
+- **Read migrations before framing the mode.** Before choosing connected vs decoupled comparison shape, the routine reads `parker-system/migrations/README.md` and any `vN.md` newer than the brain's last-applied migration, so a release that changed filesystem shape or mode behavior is in context before the offer is written.
+- **Skipped releases still carry their migrations.** If a team declined an earlier pin bump and later accepts a newer one, every `migrations/vN.md` between the old pin and the new one still runs in order. Declining a release offer does not skip the structural work those releases carried.
+
+`migrations/v2.md` ships with this release. It is a no-op for brand layout — nothing to move or create; the pin bump's normal executable-layer re-sync picks up the clearer skill.
+
+## Why
+
+Connected-mode updates were easy to under-specify: an agent could frame the offer without reading what migrations said about the current shape, and a multi-release jump after a declined bump could look like "only apply the newest migration." Both made pin bumps less reliable than the contract in `migrations/README.md` already required.
+
+## Follow-ups
+
+- Cut the `v2` tag once this merges — nothing reaches a standing brain until the tag exists.
+- No brand-side migration pass beyond the usual `/update-brain` pin bump.

--- a/templates/brand-routines/claude/skills/update-brain/SKILL.md
+++ b/templates/brand-routines/claude/skills/update-brain/SKILL.md
@@ -19,7 +19,7 @@ The factory keeps improving after a brain ships: new method docs, sharper skills
 
 Read the brain's update posture from `running-notes/standard-sync.md` first — it decides which of two shapes this comparison takes. If the ledger is missing or unreadable, say so plainly and stop; never guess at what the standard contains.
 
-Before deciding the mode, also read the `migrations/README.md` and the latest migration files from the `migrations/` folder to see if there is any new information about the shape of the filesystem and modes.
+Before deciding the mode, also read `parker-system/migrations/README.md` and any `migrations/vN.md` newer than this brain's last-applied migration — a release can change the filesystem shape or how the two modes work, and that context belongs in the comparison before the offer is framed.
 
 **Connected mode — `parker-system/` is a pinned submodule and the posture is `follow` (the standard shape).** The factory arrives whole or not at all, so there is no per-file diffing of the method: the offer is the *release*. Fetch the factory's tags (`git -C parker-system fetch --tags`) and compare the pinned release against the newest `vN` tag. If the pin is current, this comparison is one line in the digest. If the factory has moved:
 
@@ -45,7 +45,7 @@ Walk the generating prompts the brain ships in `parker-system/prompts/` against 
 
 `running-notes/standard-sync.md` is this routine's ledger: the factory remote, the update posture (`follow` / `own-factory` / `independent`), the release the brain is pinned to (or was last compared against), which migrations have been applied, and every offer with its answer — taken (and when), declined (and why, when they gave a reason), or deferred. A declined offer is not raised again unless the factory version of that item has changed since the decline. This is what makes the routine a colleague and not a nag: it remembers what the team already said.
 
-However, in the connected mode (submodule), if a user decides to accept a later version, consider the fact that all previous migrations that were skipped will likely need to run too. 
+One connected-mode caveat on that memory: if the team declined an earlier release and later accepts a newer one, every migration between the old pin and the new one still runs. Declining a *release offer* does not skip the migrations those releases carried — the pin bump walks `vN.md` in order for the whole range.
 
 ## How the offers land
 

--- a/templates/brand-routines/claude/skills/update-brain/SKILL.md
+++ b/templates/brand-routines/claude/skills/update-brain/SKILL.md
@@ -19,6 +19,8 @@ The factory keeps improving after a brain ships: new method docs, sharper skills
 
 Read the brain's update posture from `running-notes/standard-sync.md` first — it decides which of two shapes this comparison takes. If the ledger is missing or unreadable, say so plainly and stop; never guess at what the standard contains.
 
+Before deciding the mode, also read the `migrations/README.md` and the latest migration files from the `migrations/` folder to see if there is any new information about the shape of the filesystem and modes.
+
 **Connected mode — `parker-system/` is a pinned submodule and the posture is `follow` (the standard shape).** The factory arrives whole or not at all, so there is no per-file diffing of the method: the offer is the *release*. Fetch the factory's tags (`git -C parker-system fetch --tags`) and compare the pinned release against the newest `vN` tag. If the pin is current, this comparison is one line in the digest. If the factory has moved:
 
 - Name the new release and what changed — the factory's `release-notes/` entries and `migrations/` files between the pinned tag and the new one say exactly this; read them and put it in plain words.
@@ -42,6 +44,8 @@ Walk the generating prompts the brain ships in `parker-system/prompts/` against 
 ## The memory — decline once, not weekly
 
 `running-notes/standard-sync.md` is this routine's ledger: the factory remote, the update posture (`follow` / `own-factory` / `independent`), the release the brain is pinned to (or was last compared against), which migrations have been applied, and every offer with its answer — taken (and when), declined (and why, when they gave a reason), or deferred. A declined offer is not raised again unless the factory version of that item has changed since the decline. This is what makes the routine a colleague and not a nag: it remembers what the team already said.
+
+However, in the connected mode (submodule), if a user decides to accept a later version, consider the fact that all previous migrations that were skipped will likely need to run too. 
 
 ## How the offers land
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Improves `/update-brain` reliability by ensuring migration instructions are loaded before choosing connected or decoupled comparison mode. It also guarantees that accepting a later release applies every skipped migration in order, including releases previously declined.

Adds the v2 migration document and release notes, clarifying that the migration is a brand-side no-op and documenting the standard pin-bump workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->