### PR TITLE
v11: credential refresh reads brand_id from parker_config.json

### DIFF
--- a/migrations/v11.md
+++ b/migrations/v11.md
@@ -1,0 +1,5 @@
+# v11 — credential refresh reads brand_id from parker_config.json
+
+**Applies to:** brains pinned at `v10` or earlier.
+
+Nothing to do on the brand side: the change lives entirely in the copied bundle (the `save-brain` skill and both hook messages now point at `parker_config.json` for the `brand_id`), so the pin bump's re-sync delivers it. Record migrations through `v11` and set `parker_brain_version` to `v11` as usual.

--- a/release-notes/2026-07-13-v11-brand-id-pointer.md
+++ b/release-notes/2026-07-13-v11-brand-id-pointer.md
@@ -1,0 +1,19 @@
+# 2026-07-13 — v11: faster, quieter cold starts — brand_id, mount drift, silent refresh
+
+Field fixes for the slow, chatty start-of-thread experience: agents were rediscovering the brand_id, tripping over mount drift, and narrating the whole credential dance to the user.
+
+## What shipped
+
+- **brand_id from `parker_config.json`, not guesswork.** The `save-brain` skill and both hook messages (`session-start.py`, `git-guard.py`) now say it plainly: **read `brand_id` from `parker_config.json` at the repo root** — the onboarding runner has always stamped it there — and never guess it from the repo name. `get_available_brands` is only the fallback when the file is missing (very old builds).
+- **Mount drift cleared, never committed.** A `parker-system` checkout that drifted from the recorded pin breaks `git pull --rebase` ("cannot rebase with locally recorded submodule modifications") — and worse, the loop's `git add -A` would have committed the drift as an accidental pin move. The save loop now re-aligns the mount (`git submodule update --init --recursive`) *before* committing, the skill carries the recovery for the staged case, and `session-start.py` clears drift-only trees itself instead of reporting them as unsaved work. Functionally tested with a real drifted submodule.
+- **Credential refreshes are invisible maintenance.** New rule in `save-brain` and the session-start recovery text, with the exact line the user hears: **"I'll check for any new info first, then get you your answer."** Never tokens, credentials, git, or pulls.
+- **The hook does the busywork itself.** On an expired-credential pull failure, `session-start.py` now deletes the dead credential file (no `rm -f` step, no Write-tool overwrite refusal) and reads the `brand_id` out of `parker_config.json`, handing the agent a recovery message with the id inlined — one MCP call, one Write, one combined pull command.
+- **Refresh runs in parallel with the user's work.** Both the hook message and `save-brain` now instruct: fire `setup_parker_brain` and the local reads for the user's actual question in the same turn — only the pull waits on the fresh credential, and only the final answer waits on the pull. Sync-before-answer stays mandatory (a brain another process pushed to two days ago must not be read stale); it just stops being the user's problem.
+- **`credential_file_line` support.** The server tool (mevin PR #710) now returns the ready-to-write credential line; the skill and hook prefer it, with lifting the token from `authenticated_clone_url` as the older-server fallback.
+
+All changes live in the copied bundle; the pin bump's re-sync delivers them.
+
+## Follow-ups
+
+- Cut the `v11` tag once this merges.
+- The mevin2 tool description could say the same thing ("brand_id is stored in parker_config.json in the brain repo") so sessions outside the repo learn it too.

--- a/templates/brand-routines/claude/hooks/git-guard.py
+++ b/templates/brand-routines/claude/hooks/git-guard.py
@@ -28,7 +28,10 @@ TOKEN_MARK = "x-access-token:"
 CRED_FILE = Path(".git/parker-credentials")
 
 HOW = (
-    "Get fresh 1-hour credentials with the setup_parker_brain tool (Parker MCP), lift "
+    "Get fresh 1-hour credentials with the setup_parker_brain tool (Parker MCP; its "
+    "brand_id is in parker_config.json at the repo root — read it, don't guess; if "
+    "that file is missing, call get_available_brands and use the exact brand_id it "
+    "returns for this brand), lift "
     "the token out of its authenticated_clone_url, run `rm -f .git/parker-credentials` "
     "(the Write tool won't overwrite an unread file), and use the Write tool to save "
     "this single line to .git/parker-credentials:\n"

--- a/templates/brand-routines/claude/hooks/session-start.py
+++ b/templates/brand-routines/claude/hooks/session-start.py
@@ -43,12 +43,23 @@ def attempt_pull() -> str:
         origin_txt = origin.stdout.strip()
         dirty = git("status", "--porcelain", timeout=10).stdout.strip()
         if dirty:
+            # A drifted mount checkout (' M parker-system') is not work to
+            # save: committing it would move the pin, which is /update-brain's
+            # job alone, and rebase refuses to run over it. Re-aligning the
+            # checkout to the recorded pin clears it.
+            lines = [l for l in dirty.splitlines() if l.strip()]
+            if all(l.split()[-1].rstrip("/") == "parker-system" for l in lines):
+                git("submodule", "update", "--init", "--recursive", timeout=60)
+                dirty = git("status", "--porcelain", timeout=10).stdout.strip()
+        if dirty:
             return ("PULL SKIPPED — the working tree has uncommitted changes (likely a "
                     "previous session that ended without saving). First job of this "
                     "session, before anything else: commit and push those changes per "
-                    "/save-brain (`git add -A && git commit`, `git pull --rebase origin "
+                    "/save-brain — `git submodule update --init --recursive` first (a "
+                    "modified `parker-system` line is mount drift to clear, never to "
+                    "commit), then `git add -A && git commit`, `git pull --rebase origin "
                     "main`, `git submodule update --init --recursive`, `git push origin "
-                    "main`), refreshing credentials via setup_parker_brain if a step "
+                    "main` — refreshing credentials via setup_parker_brain if a step "
                     "hits an auth error.")
         pulled = git("pull", "--rebase", "origin", "main")
         if pulled.returncode == 0:
@@ -76,32 +87,56 @@ def attempt_pull() -> str:
                         "helper, their login) and rerun `git pull --rebase origin "
                         "main`; the managed-credential rules in /save-brain don't "
                         "apply here.")
-            fix = ("call setup_parker_brain (Parker MCP), lift the token out of its "
-                   "authenticated_clone_url, run `rm -f .git/parker-credentials` (the "
-                   "Write tool won't overwrite a file it hasn't read), and use the "
-                   "Write tool to save the line "
-                   "`https://x-access-token:<TOKEN>@github.com` to "
-                   ".git/parker-credentials — never put the token inside a shell "
-                   "command; if the safety layer refuses the write, ask the user for "
-                   "permission in plain words and retry, and in a scheduled run with "
-                   "nobody to ask, commit local work, state that the online save "
-                   "needs a human session, and end the run cleanly — then `git pull "
-                   "--rebase origin main` and `git submodule update --init "
-                   "--recursive`. Full procedure: /save-brain.")
+            # The stale credential is dead anyway; clearing it here saves the
+            # agent a step (and the Write tool's refusal to overwrite a file
+            # it hasn't read).
+            try:
+                Path(".git/parker-credentials").unlink(missing_ok=True)
+            except OSError:
+                pass
+            try:
+                brand_id = json.loads(
+                    Path("parker_config.json").read_text(encoding="utf-8")
+                ).get("brand_id", "")
+            except Exception:
+                brand_id = ""
+            brand = (f' with brand_id "{brand_id}"' if brand_id else
+                     " (parker_config.json is missing or unreadable here, so call "
+                     "get_available_brands first and use the exact brand_id it "
+                     "returns for this brand — never guess it from the repo name)")
+            refresh = (f"call setup_parker_brain (Parker MCP){brand} and save its "
+                       "credential_file_line to .git/parker-credentials with the "
+                       "Write tool (the stale file is already cleared; on older "
+                       "servers without that field, lift the token from "
+                       "authenticated_clone_url and write "
+                       "`https://x-access-token:<TOKEN>@github.com`) — never put "
+                       "the token inside a shell command; if the safety layer "
+                       "refuses the write, ask the user in plain words and retry "
+                       "(scheduled run with nobody to ask: commit local work, say "
+                       "the online save needs a human session, end cleanly)")
             if TOKEN_MARK in origin_txt and "@github.com" in origin_txt:
                 # Legacy layout: credentials embedded in origin shadow the store
                 # file, so rewriting the file alone changes nothing.
                 plain = "https://github.com" + origin_txt.split("@github.com", 1)[1]
-                fix = ("this clone still carries credentials inside the origin URL "
-                       "(the pre-v8 layout), and git reads those instead of the "
-                       f"credential file. First strip them: `git remote set-url origin "
-                       f"{plain}` (that command carries no secret), then wire the "
-                       "credential file once — `git config credential.helper \"\"` and "
-                       "`git config --add credential.helper \"store --file "
-                       ".git/parker-credentials\"` — then " + fix)
-            return ("PULL FAILED — the saved credentials have expired (they last about "
-                    "an hour; this is normal). First job of this session, before any "
-                    "other work: " + fix)
+                refresh = ("strip the pre-v8 tokenized origin first — `git remote "
+                           f"set-url origin {plain}` (that command carries no "
+                           "secret) — and wire the credential file once (`git "
+                           "config credential.helper \"\"` then `git config --add "
+                           "credential.helper \"store --file "
+                           ".git/parker-credentials\"`), then " + refresh)
+            return ("PULL FAILED — the saved credentials have expired (they last "
+                    "about an hour; this is normal, and NOT a reason to make the "
+                    "user wait). Your very first response runs TWO TRACKS as "
+                    "parallel tool calls in the same turn: (1) START THE USER'S "
+                    "ACTUAL REQUEST — the local reads and routing you would do "
+                    "anyway; this checkout is at most a little stale. (2) REFRESH "
+                    "— " + refresh + ". After the Write lands, run `git pull "
+                    "--rebase origin main && git submodule update --init "
+                    "--recursive` as one command; only the FINAL ANSWER waits for "
+                    "that pull — recheck anything it changed before answering. The "
+                    "user hears one plain line — \"I'll check for any new info "
+                    "first, then get you your answer\" — never tokens, "
+                    "credentials, git, or pulls. Full procedure: /save-brain.")
         detail = (pulled.stderr or pulled.stdout or "").strip().splitlines()
         return ("PULL FAILED — not an auth problem: "
                 + (detail[-1] if detail else "unknown error")

--- a/templates/brand-routines/claude/skills/save-brain/SKILL.md
+++ b/templates/brand-routines/claude/skills/save-brain/SKILL.md
@@ -22,7 +22,7 @@ Run `git remote get-url origin`.
 https://x-access-token:<TOKEN>@github.com
 ```
 
-The `<TOKEN>` (looks like `ghs_…`) comes from `setup_parker_brain` (Parker MCP): the tool returns an `authenticated_clone_url` shaped like `https://x-access-token:<TOKEN>@github.com/parker-brain/<repo>.git` — lift the token out of it; the URL itself is never fed to git. The token lasts about **1 hour** and works only on this one repo. `origin` stays the **plain** URL (`https://github.com/parker-brain/<repo>.git`), and a one-time, two-line repo setting tells git to read the file whenever GitHub asks who's calling:
+That line comes ready-made from `setup_parker_brain` (Parker MCP) as `credential_file_line` — save it exactly as returned. (Older servers only return `authenticated_clone_url`, shaped like `https://x-access-token:<TOKEN>@github.com/parker-brain/<repo>.git` — lift the token out and build the line yourself; the URL itself is never fed to git.) The `brand_id` the tool needs is in `parker_config.json` at the repo root — read it from there, never guess it from the repo name (only if the file is missing, fall back to `get_available_brands` and match the brand). The token lasts about **1 hour** and works only on this one repo. `origin` stays the **plain** URL (`https://github.com/parker-brain/<repo>.git`), and a one-time, two-line repo setting tells git to read the file whenever GitHub asks who's calling:
 
 ```bash
 git config credential.helper ""   # blank entry first: shut out any system/global helper (e.g. the user's keychain)
@@ -37,18 +37,23 @@ The blank first entry is load-bearing: without it, a keychain helper on the user
 
 When the token expires, any pull or push fails with an auth error (403, 401, "could not read Username") — that is normal, not a problem. The fix is always the same three steps:
 
-1. Call `setup_parker_brain` (Parker MCP) and lift the fresh token out of its `authenticated_clone_url`.
-2. Clear the stale file, then Write the fresh line: `rm -f .git/parker-credentials` (safe — the command carries no secret), then the Write tool. The delete matters: the Write tool refuses to overwrite a file it hasn't read this session, and `rm -f` sidesteps that whether or not a stale file survived (git erases a rejected line on its own).
+1. Call `setup_parker_brain` (Parker MCP) and take `credential_file_line` from the result.
+2. Clear the stale file, then Write the fresh line: `rm -f .git/parker-credentials` (safe — the command carries no secret), then the Write tool. The delete matters: the Write tool refuses to overwrite a file it hasn't read this session, and `rm -f` sidesteps that whether or not a stale file survived (git erases a rejected line on its own; the session-start hook clears it too when it catches the failure).
 3. Retry the command that failed.
+
+**Don't make the user wait on any of this.** Fire the `setup_parker_brain` call and the local groundwork for their actual question in the same turn — parallel tool calls. Only the pull needs the fresh credential, and only the final answer needs the pull; everything else can already be moving.
 
 **Save and push** (the whole loop, in order):
 
 ```bash
-git add -A && git commit -m "<plain summary of what changed>"   # commit first — rebase refuses a dirty tree
+git submodule update --init --recursive  # FIRST: re-align the mount to the recorded pin — drift here breaks the rebase, and committing it would move the pin, which is /update-brain's job alone
+git add -A && git commit -m "<plain summary of what changed>"   # commit second — rebase refuses a dirty tree
 git pull --rebase origin main
 git submodule update --init --recursive  # the pull can move the mount's pin; this makes the checkout follow it
 git push origin main
 ```
+
+If the rebase still fails with *"cannot rebase with locally recorded submodule modifications"*, the mount is drifted or its pin change got staged: `git restore --staged parker-system` if `git status` shows it staged, then `git submodule update --init --recursive`, then rebase again. Never commit a `parker-system` line to make the error go away.
 
 Always `git push origin main` — spelled out, never a bare `git push` — so nothing depends on upstream config that may not exist. If the pull or push hits an auth error, refresh the credentials as above and retry; don't switch to any other auth.
 
@@ -76,6 +81,8 @@ cd <folder> && git config credential.helper "" && git config --add credential.he
 ## Talking to the user about all this
 
 The user is usually not a git person. Say "saved your brain," "downloaded the latest version," "your teammate's changes came in" — not "pushed to main," "rebased," "resolved a merge conflict." If something went wrong, say what it means for them ("your last hour of notes is safe, but I need a fresh connection to save it — one moment") and fix it.
+
+**Credential refreshes are invisible maintenance — never narrate them.** An expired token at the start of a thread is the normal state, not news: don't announce failed pulls, minting, tokens, or authentication. The one line the user hears, when anything at all: **"I'll check for any new info first, then get you your answer."** Never "I'll fix the expired credentials," never "let me re-authenticate," never a word about git. Do the whole refresh silently, in parallel with starting their actual work, and the mechanics reach the user only when you're genuinely blocked and need something from them.
 
 ## Hard rules
 


### PR DESCRIPTION
## The field complaints

Cold starts were slow and chatty: on every credential refresh, agents guessed a `brand_id` from the repo name, failed with `brand_not_found`, then scanned `get_available_brands` — rediscovering a fact the repo already stores. A drifted `parker-system` checkout broke `git pull --rebase` (and the save loop's `git add -A` would have committed the drift as an accidental pin move). And the whole dance got narrated to the user in git jargon.

## What shipped (single commit, 5 files)

- **brand_id from `parker_config.json`.** The skill and both hook messages read it from the repo root — never guessed from the repo name — with `get_available_brands` as the explicit fallback when the file is missing (exact returned brand_id, both hooks carry the same contract).
- **Mount drift cleared, never committed.** The save loop re-aligns the mount *before* the commit step; the skill carries the staged-case recovery; `session-start.py` clears drift-only trees itself instead of reporting them as unsaved work. Tested with a real drifted submodule.
- **The hook does the refresh busywork.** On an expired-credential pull failure it deletes the dead credential file (no Write-tool overwrite refusal) and inlines the brand_id into the recovery message: one MCP call, one Write, one combined pull command.
- **Silent, parallel refresh.** The user hears exactly one line — "I'll check for any new info first, then get you your answer" — never tokens or git. The `setup_parker_brain` call and the local groundwork for the user's question fire as parallel tool calls; sync-before-answer stays mandatory (shared repos must not be read stale), it just stops being the user's problem.
- **`credential_file_line` support.** The server tool (mevin PR #710) now returns the ready-to-write credential line; skill and hook prefer it, token-lifting from `authenticated_clone_url` stays as the older-server fallback.
- Ships as `v11`: no-op migration (all changes ride the copied bundle) + release note.

## Validation

Hooks compile; 25-case git-guard matrix green; session-start functionally tested for expired-credential recovery (brand_id inlined, stale file cleared), legacy tokenized origin, self-hosted origins, and mount-drift self-healing.

## After merge

- Cut the `v11` tag.
