### PR TITLE
migrations/v12: stage the pin as step 0 — the transition escape hatch

### DIFF
--- a/migrations/v12.md
+++ b/migrations/v12.md
@@ -1,0 +1,17 @@
+# v12 — stage the pin move first (transition guard), then business as usual
+
+**Applies to:** brains pinned at `v11` or earlier.
+
+## Step 0 — run this before reading anything else
+
+From the brain's **root folder** (not inside `parker-system/`), run:
+
+```bash
+git add parker-system
+```
+
+Why this must happen now: you just checked out the new tag, and the update procedure your brain currently carries (`v11`) does not stage the pin move — it commits the pin only at the very end. But your brain's `v11` save loop and session-start hook re-align the mount to the pin recorded in the **index**, so an unstaged move gets silently reverted mid-update and the release half-lands (new bundle files, old pin). Staging protects it: a staged pin survives every `git submodule update --init --recursive` that follows. From this release on, the updated `/update-brain` stages the pin itself the moment it moves — this step exists to protect the one update that runs under the old procedure.
+
+## Then
+
+Nothing else to do: the rest of this release (the staged-pin discipline in `update-brain` and `save-brain`, the session-start message that tells unstaged drift apart from a staged pin move, the restructured factory README) rides the copied bundle or the factory itself, and the pin bump's re-sync delivers it. Record migrations through `v12` and set `parker_brain_version` to `v12` as usual.


### PR DESCRIPTION
## Why a migration carries this

The staged-pin fix (#47, merged) ships inside the copied bundle — which arrives via the very update the unstaged-pin bug can revert. A v11 brain updating to v12 runs its **old** `update-brain` and save loop: the pin move sits unstaged from checkout until the closing save, where the old loop's re-align silently snaps the mount back to v11 and the release half-lands (new bundle files, old pin).

The migration file is the one piece of new-release content the old procedure is guaranteed to read and execute **immediately after the checkout** — it comes from the freshly checked-out v12 mount, not from the brain's stale bundle. So `v12.md` opens with step 0: `git add parker-system` from the brain root. A staged pin survives every `git submodule update --init --recursive` that follows (verified by repro in #47), which protects the one update that runs under the old regime.

One-time transition guard: from v12 on, the updated `update-brain` stages the pin itself, so later migrations don't need this step.

Note: `migrations/v12.md` now exists ahead of the tag — anything else landing before the v12 cut extends this file; the release note comes with the cut.

(Housekeeping: #47's branch was auto-deleted on merge and my push accidentally resurrected it; it's deleted again and this PR is a clean cherry-pick onto current main.)