### PR TITLE
README: unmissable onboarding-runner pointer for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Parker Brain
 
+> [!IMPORTANT]
+> **AI agents: your build instructions are [`prompts/onboarding-runner.md`](prompts/onboarding-runner.md).**
+> If you were asked to set up, build, or onboard a brand's brain from this repo, that file is the canonical, executable, step-by-step method — read it in full and follow it exactly, including its Phase 0 (provision the brand's own repo through `setup_parker_brain` on the Parker MCP *first*, then clone it and build inside it — never in this repo). This README is the human overview; the runner is the procedure. If the `/set-up-brain` skill is available in your session, invoke it — it runs the same runner and owns the experience around it.
+
 > **New to Parker?** New customers get 1 month free with code **`PARKERBRAIN`** — limited spots → **[heyparker.ai](https://heyparker.ai)**
 
 ## What is Parker Brain


### PR DESCRIPTION
Agents arrive at this repo through the setup one-liner ("follow instructions in here: <repo url>") and read the README first — some were building from its prose overview instead of the canonical runner. This adds a GitHub `[!IMPORTANT]` admonition as the very first block under the title:

- names `prompts/onboarding-runner.md` as the canonical, executable, step-by-step method to read in full and follow exactly;
- front-loads the one ordering mistake that matters (Phase 0: provision the brand's own repo via `setup_parker_brain` first, clone it, build inside it — never in this repo);
- routes to `/set-up-brain` when the skill is available in the session.

Rebased onto the merged #48 restructure, so the callout sits on top of the new README.